### PR TITLE
change paths to match development branch

### DIFF
--- a/R/pkg-setup.R
+++ b/R/pkg-setup.R
@@ -128,8 +128,10 @@ isJaspRequiredFilesDir <- function(path) {
 }
 
 isJaspDesktopDir <- function(path) {
-  dirs <- dir(path, pattern = "JASP-*")
-  return(all(c("JASP-Common", "JASP-Desktop", "JASP-Engine", "JASP-R-Interface") %in% dirs))
+  dirs <- list.dirs(path, full.names = FALSE, recursive = FALSE)
+  return(all(
+    c("Common", "Desktop", "Docs", "Engine", "Modules", "R-Interface", "Resources", "Tests", "Tools") %in% dirs
+  ))
 }
 
 findRequiredPkgs <- function(pathToRequiredFiles) {


### PR DESCRIPTION
Alternatively, we could use the code below
```r
info <- jsonlite::read_json("https://api.github.com/repos/jasp-stats/jasp-desktop/contents/")
sapply(info, `[[`, "name")
```
which fetches all file and directory names in the top-level git of the default branch. That does require an internet connection and is probably overkill, so I just hardcoded the paths.
