### PR TITLE
Improve unit test error messages and allow empty testthat folders

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspTools
 Type: Package
 Title: Helps preview and debug JASP analyses
-Version: 1.3.2
+Version: 1.4.0
 Author: Tim de Jong
 Maintainer: Tim de Jong <tim_jong@hotmail.com>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,9 +10,9 @@ Encoding: UTF-8
 LazyData: true
 Imports:
   data.table,
-  devtools,
   httr,
   jsonlite,
+  pkgload,
   remotes,
   rjson,
   stringi,

--- a/R/options.R
+++ b/R/options.R
@@ -103,12 +103,12 @@ getQMLFile <- function(name) {
   fileContents <- gsub("[\"']", "", fileContents)
   rFuncLocExpr <- paste0("\\{[^\\{\\}]*func:\\s*", name, "[^\\{\\}]*\\}")
   if (!grepl(rFuncLocExpr, fileContents))
-    stop("Could not locate qml file for R function ", name, " in inst/qml folder and did not find the R function in inst/Description.qml to look for an alternative name for the qml file")
+    stop("Could not locate qml file for R function ", name, " in inst/qml directory and did not find the R function in inst/Description.qml to look for an alternative name for the qml file")
 
   rLocMatch <- stringr::str_match(fileContents, rFuncLocExpr)[1]
   qmlLocExpr <- "[a-zA-Z0-9_]+\\.qml"
   if (!grepl(qmlLocExpr, rLocMatch))
-    stop("Could not locate qml file for R function ", name, " in inst/qml folder and did not find a qml entry in inst/Description.qml that describes an alternative for the qml filename")
+    stop("Could not locate qml file for R function ", name, " in inst/qml directory and did not find a qml entry in inst/Description.qml that describes an alternative for the qml filename")
 
   qmlFileName <- stringr::str_match(rLocMatch, qmlLocExpr)
   qmlFilePath <- file.path(modulePath, "inst", "qml", qmlFileName)

--- a/R/pkg-settings.R
+++ b/R/pkg-settings.R
@@ -26,7 +26,7 @@
 #'
 #' @details \code{module.dirs}:
 #' The directories that hold the source for the JASP module(s) you are working on.
-#' These module folders are used to find the R functions etc. in \code{runAnalysis} and the various testing functions.
+#' These module directories are used to find the R functions etc. in \code{runAnalysis} and the various testing functions.
 #'
 #' @return A print of the configurable options.
 #' @export viewPkgOptions
@@ -76,9 +76,9 @@ setPkgOption <- function(name, value) {
         next
 
       if (!dir.exists(value[i])) # if the value is not a null value it should be a valid path
-        stop("Folder ", value[i], " does not exist")
+        stop("Directory ", value[i], " does not exist")
 
-      value[i] <- gsub("[\\/]$", "", normalizePath(value[i])) # normalize path and strip trailing slashes (they trip up devtools::as.package)
+      value[i] <- gsub("[\\/]$", "", normalizePath(value[i])) # normalize path and strip trailing slashes
     }
   }
 

--- a/R/pkg-setup.R
+++ b/R/pkg-setup.R
@@ -434,9 +434,9 @@ downloadAllJaspModules <- function(force = FALSE, quiet = FALSE) {
   repos <- getJaspGithubRepos()
   result <- list(success = NULL, fail = NULL)
   for (repo in repos) {
-    if (!is.null(names(repo)) && c("name", "full_name") %in% names(repo)) {
-      if (isRepoJaspModule(repo[["name"]]) && (force || !force && !repo[["name"]] %in% installed.packages())) {
-        success <- downloadJaspPkg(repo[["name"]], quiet)
+    if (!is.null(names(repo)) && c("name", "default_branch") %in% names(repo)) {
+      if (isRepoJaspModule(repo[["name"]], repo[["default_branch"]]) && (force || !force && !repo[["name"]] %in% installed.packages())) {
+        success <- downloadJaspPkg(repo[["name"]], repo[["default_branch"]], quiet)
         if (success)
           result[["success"]] <- c(result[["success"]], repo[["name"]])
         else
@@ -450,8 +450,8 @@ downloadAllJaspModules <- function(force = FALSE, quiet = FALSE) {
   invisible(result)
 }
 
-downloadJaspPkg <- function(repo, quiet) {
-  url <- sprintf("https://github.com/jasp-stats/%1$s/%2$s/%3$s", repo, "archive", "master.zip")
+downloadJaspPkg <- function(repo, branch, quiet) {
+  url <- sprintf("https://github.com/jasp-stats/%1$s/archive/%2$s.zip", repo, branch)
   baseLoc <- getTempJaspModulesLocation()
   pkgLoc <- file.path(baseLoc, repo)
   zipFile <- file.path(baseLoc, paste0(repo, ".zip"))
@@ -467,8 +467,8 @@ downloadJaspPkg <- function(repo, quiet) {
 
     unzip(zipfile = zipFile, exdir = baseLoc)
 
-    if (dir.exists(paste0(pkgLoc, "-master")))
-      file.rename(paste0(pkgLoc, "-master"), pkgLoc)
+    if (dir.exists(paste0(pkgLoc, "-", branch)))
+      file.rename(paste0(pkgLoc, "-", branch), pkgLoc)
 
     if (file.exists(zipFile))
       unlink(zipFile)
@@ -477,8 +477,8 @@ downloadJaspPkg <- function(repo, quiet) {
   return(TRUE)
 }
 
-isRepoJaspModule <- function(repo) {
-  repoTree <- githubGET(asGithubReposUrl("jasp-stats", repo, c("git", "trees", "master"), params = list(recursive = "false")))
+isRepoJaspModule <- function(repo, branch) {
+  repoTree <- githubGET(asGithubReposUrl("jasp-stats", repo, c("git", "trees", branch), params = list(recursive = "false")))
   if (length(names(repoTree)) > 0 && "tree" %in% names(repoTree)) {
     pathNames <- unlist(lapply(repoTree[["tree"]], `[[`, "path"))
     return(hasJaspModuleRequisites(pathNames, sep = "/"))

--- a/R/pkg-setup.R
+++ b/R/pkg-setup.R
@@ -250,7 +250,7 @@ readJaspRequiredFilesLocation <- function() {
 
 setLocationJaspRequiredFiles <- function(pathToRequiredFiles) {
   if (!dir.exists(pathToRequiredFiles))
-    stop("jasp-required-files folder does not exist at ", pathToRequiredFiles)
+    stop("jasp-required-files directory does not exist at ", pathToRequiredFiles)
 
   path <- normalizePath(pathToRequiredFiles)
   libPath <- findRequiredPkgs(path)
@@ -481,7 +481,7 @@ isRepoJaspModule <- function(repo, branch) {
   repoTree <- githubGET(asGithubReposUrl("jasp-stats", repo, c("git", "trees", branch), params = list(recursive = "false")))
   if (length(names(repoTree)) > 0 && "tree" %in% names(repoTree)) {
     pathNames <- unlist(lapply(repoTree[["tree"]], `[[`, "path"))
-    return(hasJaspModuleRequisites(pathNames, sep = "/"))
+    return(all(moduleRequisites(sep = "/") %in% pathNames))
   }
 
   return(FALSE)

--- a/R/test.R
+++ b/R/test.R
@@ -123,7 +123,7 @@ testAll <- function() {
 #' tested.
 #' @return A Shiny app that shows all new/failed/orphaned cases. The app allows
 #' test plots to be validated, at which point they are placed in the figs
-#' folder and used as a reference for future tests.
+#' directory and used as a reference for future tests.
 #' @examples
 #'
 #' # manageTestPlots("Anova")
@@ -175,7 +175,7 @@ manageTestPlots <- function(name = NULL) {
 #'
 #'
 #' @param dep A single character value of a package name currently installed on your system
-#' @param modulePath Specify the path to the root folder of the module, or specify it through `setPkgOption("/.../")`
+#' @param modulePath Specify the path to the root directory of the module, or specify it through `setPkgOption("/.../")`
 #' @return This function only has a side effect: updating figs/jasp-deps.txt
 #' @examples
 #'

--- a/R/test.R
+++ b/R/test.R
@@ -37,7 +37,7 @@ runTestsTravis <- function(modulePath) {
 #'
 #' @export testAnalysis
 testAnalysis <- function(name) {
-  modulePath <- getModulePathsForTesting(name)
+  modulePath <- getModulePathFromRFunction(name)
 
   testDir    <- file.path(modulePath, "tests", "testthat")
   nameMatch  <- matchCaseTestFileAnalysisName(name, testDir)
@@ -130,9 +130,11 @@ testAll <- function() {
 #'
 #' @export manageTestPlots
 manageTestPlots <- function(name = NULL) {
-  modulePaths <- getModulePathsForTesting(name)
 
-  if (!is.null(name)) {
+  if (is.null(name)) {
+    modulePaths <- getModulePathsForTesting()
+  } else {
+    modulePaths <- getModulePathFromRFunction(name)
     name <- matchCaseTestFileAnalysisName(name, file.path(modulePaths, "tests", "testthat"))
     name <- paste0("^", name, "$")
   }

--- a/R/testthat-helper-plots.R
+++ b/R/testthat-helper-plots.R
@@ -21,7 +21,7 @@
 #' @export expect_equal_plots
 expect_equal_plots <- function(test, name, dir) {
   if (length(test) == 0) {
-    expect(FALSE, getEmptyTestMsg("plot"))
+    expect(FALSE, getEmptyTestMsg("expect_equal_plots()"))
     return()
   }
 
@@ -53,15 +53,15 @@ skip_if_recordedPlot <- function(test) {
     skip("Recorded plots are skipped until the scaling of these plots is fixed")
 }
 
-getEmptyTestMsg <- function(element) {
+getEmptyTestMsg <- function(expectationFn) {
   error <- getErrorMsgFromLastResults()
   if (!is.null(error[["type"]])) {
     if (error[["type"]] == "validationError" || error[["type"]] == "fatalError")
-      msg <- paste0("Tried retrieving ", element, " from results, but last run of jaspTools exited with a ", error[["type"]], ":\n\n", error[["message"]])
+      msg <- paste0("The `test` argument provided to `", expectationFn, "` is empty. Likely reason: the last run of jaspTools exited with a ", error[["type"]], ":\n\n", error[["message"]])
     else if (error[["type"]] == "localError")
-      msg <- paste0("The new ", element, " has no data. Please check the validity of your unit test; found the following local errors in the results:\n\n", error[["message"]])
+      msg <- paste0("The `test` argument provided to `", expectationFn,"` is empty. Likely reasons: (1) the path to the results in the unit test is not correct, or (2) one of the following errors in the results interfered with the test:\n\n", error[["message"]])
   } else {
-    msg <- paste0("The new ", element, " has no data. Please check the validity of your unit test; is the index path to the plot specified correctly?")
+    msg <- paste0("The `test` argument provided to `", expectationFn,"` is empty. Likely reason: the path to the results in the unit test is not correct.")
   }
 
   return(msg)

--- a/R/utils.R
+++ b/R/utils.R
@@ -26,13 +26,13 @@ getModulePaths <- function() {
       setPkgOption("module.dirs", wdAsPkg)
       validModules <- wdAsPkg
     } else {
-      stop("No module folders were specified through `setPkgOption(\"module.dirs\", ...)`. Please add the ones you are working on and want to run or test.")
+      stop("jaspTools needs to know what module to obtain resources from. Please set the current working directory to your JASP module, or specify it through `setPkgOption(\"module.dirs\", \"path/to/module\")`")
     }
 
   }
 
   if (length(validModules) == 0)
-    stop("None of the module folders specified through `setPkgOption(\"module.dirs\", ...)` are valid JASP modules. All JASP modules have these files: DESCRIPTION, NAMESPACE, inst/Description.qml.")
+    stop("None of the module folders specified through `setPkgOption(\"module.dirs\", ...)` are valid JASP modules. All JASP modules should be valid R packages and have these files: DESCRIPTION, NAMESPACE, inst/Description.qml.")
 
   return(validModules)
 }
@@ -198,7 +198,7 @@ getOS <- function() {
 }
 
 getJaspGithubRepos <- function() {
-  githubGET(asGithubOrganizationUrl("jasp-stats", "repos", params = list(type = "public", "per_page" = 1e3)))
+  githubGET(asGithubOrganizationUrl("jasp-stats", "repos", params = list(type = "public", per_page = 1e3)))
 }
 
 asGithubOrganizationUrl <- function(owner, urlSegments = NULL, params = list()) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -75,13 +75,9 @@ rFunctionExistsInModule <- function(name, modulePath) {
   return(FALSE)
 }
 
-getModulePathsForTesting <- function(name = NULL) {
-  if (!is.null(name))
-    modulePaths <- getModulePathFromRFunction(name)
-  else
-    modulePaths <- getModulePaths()
-
+getModulePathsForTesting <- function() {
   modulesWithTests <- NULL
+  modulePaths <- getModulePaths()
   for (modulePath in modulePaths) {
     testDir <- file.path(modulePath, "tests", "testthat")
     if (dir.exists(testDir) && length(list.files(testDir)) > 0)
@@ -89,7 +85,7 @@ getModulePathsForTesting <- function(name = NULL) {
   }
 
   if (length(modulesWithTests) == 0)
-    stop("None of the module folders specified in `module.dirs` (see `viewPkgOptions()`) have any tests. Note that the tests should be in `moduleDir/tests/testthat` and named `test-analysisName.R`.")
+    message("No tests were found. Note that the tests should be in `moduleDir/tests/testthat` and named `test-analysisName.R`.")
 
   return(modulesWithTests)
 }
@@ -163,7 +159,7 @@ getErrorMsgFromLastResults <- function() {
   if (is.null(error[["type"]])) {
     flatResults <- unlist(lastResults)
     localErrors <- endsWith(names(flatResults), ".error.errorMessage")
-    if (length(localErrors) > 0) {
+    if (sum(localErrors) > 0) {
       posInResults <- gsub(".error.errorMessage", "", names(flatResults)[localErrors], fixed = TRUE)
       msgs <- flatResults[localErrors]
       error[["type"]] <- "localError"

--- a/R/view.R
+++ b/R/view.R
@@ -7,7 +7,7 @@
 #'
 #' @param results A named R list returned from a JASP analysis, or a json
 #' results string copied from the Qt terminal.
-#' @return A html page is generated and placed in a temp folder.
+#' @return A html page is generated and placed in a temp directory
 #' @examples
 #'
 #' options <- analysisOptions("BinomialTest")

--- a/man/addTestDependency.Rd
+++ b/man/addTestDependency.Rd
@@ -9,7 +9,7 @@ addTestDependency(dep, modulePath = getPkgOption("module.dirs"))
 \arguments{
 \item{dep}{A single character value of a package name currently installed on your system}
 
-\item{modulePath}{Specify the path to the root folder of the module, or specify it through `setPkgOption("/.../")`}
+\item{modulePath}{Specify the path to the root directory of the module, or specify it through `setPkgOption("/.../")`}
 }
 \value{
 This function only has a side effect: updating figs/jasp-deps.txt

--- a/man/installJaspPkg.Rd
+++ b/man/installJaspPkg.Rd
@@ -13,8 +13,8 @@ installJaspPkg(pkg, force = FALSE, auth_token = NULL, ...)
 
 \item{auth_token}{To install from a private repo, generate a personal access token (PAT) in "https://github.com/settings/tokens" and supply to this argument. This is safer than using a password because you can easily delete a PAT without affecting any others. Defaults to the GITHUB_PAT environment variable.}
 
-\item{...}{Passed on to \code{devtools::install_github}}
+\item{...}{Passed on to \code{remotes::install_github}}
 }
 \description{
-Thin wrapper around devtools::install_github.
+Thin wrapper around remotes::install_github.
 }

--- a/man/manageTestPlots.Rd
+++ b/man/manageTestPlots.Rd
@@ -13,7 +13,7 @@ tested.}
 \value{
 A Shiny app that shows all new/failed/orphaned cases. The app allows
 test plots to be validated, at which point they are placed in the figs
-folder and used as a reference for future tests.
+directory and used as a reference for future tests.
 }
 \description{
 This function is a wrapper around \code{vdiffr::manage_cases()}. It allows

--- a/man/runAnalysis.Rd
+++ b/man/runAnalysis.Rd
@@ -4,8 +4,14 @@
 \alias{runAnalysis}
 \title{Run a JASP analysis in R.}
 \usage{
-runAnalysis(name, dataset, options, view = TRUE, quiet = FALSE,
-  makeTests = FALSE)
+runAnalysis(
+  name,
+  dataset,
+  options,
+  view = TRUE,
+  quiet = FALSE,
+  makeTests = FALSE
+)
 }
 \arguments{
 \item{name}{String indicating the name of the analysis to run. This name is
@@ -13,7 +19,7 @@ identical to that of the main function in a JASP analysis.}
 
 \item{dataset}{Data.frame, matrix, string name or string path; if it's a string then jaspTools
 first checks if it's valid path and if it isn't if the string matches one of the JASP datasets (e.g., "debug.csv").
-By default the folder in Resources is checked first, unless called within a testthat environment, in which case tests/datasets is checked first.}
+By default the directory in Resources is checked first, unless called within a testthat environment, in which case tests/datasets is checked first.}
 
 \item{options}{List of options to supply to the analysis (see also
 \code{analysisOptions}).}

--- a/man/setupJaspTools.Rd
+++ b/man/setupJaspTools.Rd
@@ -4,9 +4,14 @@
 \alias{setupJaspTools}
 \title{Setup the jaspTools package.}
 \usage{
-setupJaspTools(pathJaspDesktop = NULL, pathJaspRequiredPkgs = NULL,
-  installJaspModules = TRUE, installJaspCorePkgs = TRUE,
-  quiet = FALSE, force = TRUE)
+setupJaspTools(
+  pathJaspDesktop = NULL,
+  pathJaspRequiredPkgs = NULL,
+  installJaspModules = FALSE,
+  installJaspCorePkgs = TRUE,
+  quiet = FALSE,
+  force = TRUE
+)
 }
 \arguments{
 \item{pathJaspDesktop}{[optional] Character path to the root of jasp-desktop if present on the system.}

--- a/man/view.Rd
+++ b/man/view.Rd
@@ -11,7 +11,7 @@ view(results)
 results string copied from the Qt terminal.}
 }
 \value{
-A html page is generated and placed in a temp folder.
+A html page is generated and placed in a temp directory
 }
 \description{
 \code{view} allows you to view output independently of JASP. By default this output

--- a/man/viewPkgOptions.Rd
+++ b/man/viewPkgOptions.Rd
@@ -37,5 +37,5 @@ This option specifies if the installed version should be reinstalled automatical
 
 \code{module.dirs}:
 The directories that hold the source for the JASP module(s) you are working on.
-These module folders are used to find the R functions etc. in \code{runAnalysis} and the various testing functions.
+These module directories are used to find the R functions etc. in \code{runAnalysis} and the various testing functions.
 }


### PR DESCRIPTION
I don't want unit tests to fail when there are no tests present (for example in the jaspModuleTemplate), so I reduced that to just a normal message.
Also some messages were not great, so I tried to make them a bit more clear. Most notably the table diff:

Before:
![old-table-unit-test-diff](https://user-images.githubusercontent.com/18737241/102366700-3ffd5a00-3fb9-11eb-9868-b2e765f9b3d4.png)

After:
![new-table-unit-test-diff](https://user-images.githubusercontent.com/18737241/102366698-3ffd5a00-3fb9-11eb-813d-32f8b574e7e9.png)
