### PR TITLE
Add support for test-verified-*.R files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspTools
 Type: Package
 Title: Helps preview and debug JASP analyses
-Version: 1.4.0
+Version: 1.4.1
 Author: Tim de Jong
 Maintainer: Tim de Jong <tim_jong@hotmail.com>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.


### PR DESCRIPTION
This makes it possible to call `jaspTools::testAnalysis("Descriptives")` and have both `test-verified-descriptives.R` and `test-descriptives.R` be tested. The same goes for `jaspTools::manageTestPlots("Descriptives")`