### PR TITLE
add support for binary modules

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -90,11 +90,20 @@ getQMLFile <- function(name) {
   if (is.null(modulePath))
     stop("Could not locate the module location for ", name)
 
-  possibleQmlFile <- file.path(modulePath, "inst", "qml", paste0(name, ".qml")) # it's optional to specify the qml file in Description.qml, you can also just name it RFunc.qml
+  if (isBinaryPackage(modulePath)) {
+    qmlDir  <- file.path(modulePath, "qml")
+    instDir <- modulePath
+  } else { # source pkg
+    qmlDir  <- file.path(modulePath, "inst", "qml")
+    instDir <- file.path(modulePath, "inst")
+
+  }
+
+  possibleQmlFile <- file.path(qmlDir, paste0(name, ".qml")) # it's optional to specify the qml file in Description.qml, you can also just name it RFunc.qml
   if (file.exists(possibleQmlFile))
     return(possibleQmlFile)
 
-  descrFile <- file.path(modulePath, "inst", "Description.qml")
+  descrFile <- file.path(instDir, "Description.qml")
   if (!file.exists(descrFile))
     stop("Could not locate Description.qml in ", modulePath)
 
@@ -111,7 +120,7 @@ getQMLFile <- function(name) {
     stop("Could not locate qml file for R function ", name, " in inst/qml directory and did not find a qml entry in inst/Description.qml that describes an alternative for the qml filename")
 
   qmlFileName <- stringr::str_match(rLocMatch, qmlLocExpr)
-  qmlFilePath <- file.path(modulePath, "inst", "qml", qmlFileName)
+  qmlFilePath <- file.path(qmlDir, qmlFileName)
   if (!file.exists(qmlFilePath))
     stop("Found a qml filename for the R function ", name, " but this qml file does not appear to exist in inst/qml/")
 

--- a/R/run.R
+++ b/R/run.R
@@ -151,6 +151,10 @@ reinstallChangedModules <- function() {
 
   md5Sums <- .getInternal("modulesMd5Sums")
   for (modulePath in modulePaths) {
+
+    if (isBinaryPackage(modulePath))
+      next
+
     srcFiles <- c(
       list.files(modulePath,                   full.names = TRUE, pattern = "(NAMESPACE|DESCRIPTION)$"),
       list.files(file.path(modulePath, "src"), full.names = TRUE, pattern = "(\\.(cpp|c|hpp|h)|(Makevars|Makevars\\.win))$"),

--- a/R/test.R
+++ b/R/test.R
@@ -6,11 +6,18 @@
 #'
 #' @export runTestsTravis
 runTestsTravis <- function(modulePath) {
-  if (Sys.getenv("CI") == "") {
+  if (Sys.getenv("CI") == "" && Sys.getenv("R_COVR") == "") {
     testAll()
   } else {
     if (!.isSetupComplete())
       stop("The setup should be completed before the tests are ran")
+
+    # this check is identical to covr::in_covr()
+    if (identical(Sys.getenv("R_COVR"), "true")) {
+      # inside covr::package_coverage, getwd() is one directory deeper (the test directory)
+      # fixing this here avoids adding an if statement to every testthat.R
+      modulePath <- normalizePath(file.path(modulePath, ".."))
+    }
 
     setPkgOption("module.dirs", modulePath)
 

--- a/R/test.R
+++ b/R/test.R
@@ -12,16 +12,14 @@ runTestsTravis <- function(modulePath) {
     if (!.isSetupComplete())
       stop("The setup should be completed before the tests are ran")
 
-    # this check is identical to covr::in_covr()
-    if (identical(Sys.getenv("R_COVR"), "true")) {
-      # inside covr::package_coverage, getwd() is one directory deeper (the test directory)
-      # fixing this here avoids adding an if statement to every testthat.R
-      modulePath <- normalizePath(file.path(modulePath, ".."))
-    }
-
     setPkgOption("module.dirs", modulePath)
 
-    remotes::install_local(modulePath, upgrade = "never", force = FALSE, INSTALL_opts = "--no-multiarch")
+    # this check is identical to covr::in_covr()
+    codeCoverage <- identical(Sys.getenv("R_COVR"), "true")
+
+    # only install the pkg if we're not running on covr, because covr also installs it
+    if (!codeCoverage)
+      remotes::install_local(modulePath, upgrade = "never", force = FALSE, INSTALL_opts = "--no-multiarch")
 
     testingStatus <- testAll()
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -123,8 +123,13 @@ moduleRequisites <- function(sep = .Platform$file.sep) {
   return(c("NAMESPACE", "DESCRIPTION", paste("inst", "Description.qml", sep = sep)))
 }
 
+binaryModuleRequisites <- function() {
+  return(c("NAMESPACE", "DESCRIPTION", "Description.qml", "qml", "Meta"))
+}
+
 hasJaspModuleRequisites <- function(path) {
-  all(file.exists(file.path(path, moduleRequisites())))
+  all(file.exists(file.path(path, moduleRequisites()))) ||
+    all(file.exists(file.path(path, binaryModuleRequisites())))
 }
 
 insideTestEnvironment <- function() {


### PR DESCRIPTION
You can see it in action here:

jaspJags: https://github.com/vandenman/jaspJags/pull/1
jaspNetwork: https://github.com/vandenman/jaspNetwork/pull/1

the required changes to the modules are actually quite small.

We still need to discuss some other things regarding coverage (e.g., what information do we want to see? A comment? Will tests fail due to a decrease in coverage? If yes, at what % decrease? etc., see also https://docs.codecov.io/docs/pull-request-comments) but maybe we should do that in a PR that actually shows the differences.