### PR TITLE
Check for length 1 in if statement

### DIFF
--- a/R/pkg-settings.R
+++ b/R/pkg-settings.R
@@ -69,7 +69,7 @@ setPkgOption <- function(name, value) {
   # set relative paths to absolute paths to ensure they will work if the wd changes
   if (any(endsWith(name, c(".dir", ".dirs")))) {
     for (i in seq_along(value)) {
-      if (is.null(value) || value == "") # allow users to reset paths to null values
+      if (length(value) == 1L && (is.null(value) || value == "")) # allow users to reset paths to null values
         next
 
       if (!dir.exists(value[i])) # if the value is not a null value it should be a valid path


### PR DESCRIPTION
As you may have noticed, when you do `library(jaspTools)` or `setupJaspTools()` you get this:
![image](https://user-images.githubusercontent.com/21319932/172359832-f7408414-f544-4d87-93b7-a0f82e3e592d.png)

these warnings will become errors in a future version of R. You can also test this locally with
```r
jaspTools:::.onLoad(.libPaths()[1], "jaspTools")
```