### PR TITLE
Fix plot paths in `view()`

### DIFF
--- a/R/view.R
+++ b/R/view.R
@@ -174,6 +174,11 @@ createHtmlFile <- function(json) {
       jQuery(function($) {
         $(document).ready(function() {
           window.analysisChanged(", json, ")
+          HTMLCollection.prototype.forEach = Array.prototype.forEach;
+          imgs = document.getElementsByClassName('jasp-image-image');
+          imgs.forEach(function(el, i) {
+            imgs[i].style.backgroundImage = imgs[i].style.backgroundImage.replace('plot://', '')
+          })
         })
       })
     </script></body>")


### PR DESCRIPTION
In JASP, plots have their own scheme `plot://`. This does not work in `jaspTools::view()`, so the figures are not displayed. Here I add quite a simplistic fix: just remove `plot://` from the paths when we are in R Studio. Not the most elegant solution, but it seems to work. I welcome any suggestions to make it less hacky.