### PR TITLE
add method to specify a custom tolerance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspTools
 Type: Package
 Title: Helps preview and debug JASP analyses
-Version: 1.5.1
+Version: 1.5.2
 Author: Tim de Jong
 Maintainer: Tim de Jong <tim_jong@hotmail.com>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.
@@ -20,5 +20,5 @@ Imports:
   stringr,
   testthat (>= 3.0.3),
   vdiffr (>= 1.0.2)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)

--- a/man/expect_equal_tables.Rd
+++ b/man/expect_equal_tables.Rd
@@ -16,6 +16,10 @@ expect_equal_tables(test, ref, label = NULL)
 \description{
 This function compares a stored list of table data, to the table that is created when the tests are run.
 }
+\details{
+By default, numbers are compared using \code{signif(round(x, digits = 4), digits = 4)}. A custom function to use for rounding numeric values can be passed by setting
+\code{options("jaspRoundToPrecision")}. This function should return \emph{numbers} rounded to the desired accuracy.
+}
 \examples{
 
 options <- analysisOptions("BinomialTest")
@@ -29,5 +33,17 @@ table <- results[["results"]][["binomialTable"]][["data"]]
 expect_equal_tables(table,
                     list("TRUE", 1, 58, 0, 0.492841460660175, 0.696739870156555, 0.58, 100, 1, "contBinom",
                          "FALSE", 1, 42, 1, 0.336479745077558, 0.999903917924738, 0.42, 100, 1, "contBinom"))
+
+# illustration of custom tolerance
+expect_equal_tables(list(0.50001), list(0.50000))
+try(expect_equal_tables(list(0.51), list(0.50)))
+
+# increase tolerance
+options("jaspRoundToPrecision" = function(x) signif(round(x, digits = 1), digits = 1))
+expect_equal_tables(list(0.51), list(0.50))
+
+# reset tolerance to default
+options("jaspRoundToPrecision" = NULL) # reset default
+try(expect_equal_tables(list(0.51), list(0.50)))
 
 }


### PR DESCRIPTION
Allow a custom tolerance to be specified by the developer for the unit tests.

@koenderks could use this for the Bain unit tests (see https://github.com/jasp-stats/jaspBain/pull/83) where only on Linux there is something weird with the reproducibility, and increasing the tolerance would be an easy fix.