### PR TITLE
fix multiple length logical in if statement when installing all jaspModules

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: jaspTools
 Type: Package
 Title: Helps preview and debug JASP analyses
-Version: 1.5.2
+Version: 1.5.3
 Author: Tim de Jong
 Maintainer: Tim de Jong <tim_jong@hotmail.com>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.

--- a/R/pkg-setup.R
+++ b/R/pkg-setup.R
@@ -300,7 +300,7 @@ downloadAllJaspModules <- function(force = FALSE, quiet = FALSE) {
   repos <- getJaspGithubRepos()
   result <- list(success = NULL, fail = NULL)
   for (repo in repos) {
-    if (!is.null(names(repo)) && c("name", "default_branch") %in% names(repo)) {
+    if (!is.null(names(repo)) && all(c("name", "default_branch") %in% names(repo))) {
       if (isRepoJaspModule(repo[["name"]], repo[["default_branch"]]) && (force || !force && !repo[["name"]] %in% installed.packages())) {
         success <- downloadJaspPkg(repo[["name"]], repo[["default_branch"]], quiet)
         if (success)


### PR DESCRIPTION
@JohnnyDoorn with this PR the following snippet should work again:
```r
setupJaspTools(pathJaspDesktop = "~/GitHubStuff/jasp-desktop/",
               installJaspModules = TRUE, installJaspCorePkgs = TRUE, quiet = FALSE, force = TRUE)
```

you can test this by first installing this PR with
```
remotes::install_github("vandenman/jaspTools@fixLengthIfStatement")
```

