### PR TITLE
Column type conversions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,6 +19,9 @@ Imports:
   stringi,
   stringr,
   testthat (>= 3.0.3),
-  vdiffr (>= 1.0.2)
+  vdiffr (>= 1.0.2),
+  jaspBase
+Remotes:
+  jasp-stats/jaspBase
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)

--- a/R/rbridge.R
+++ b/R/rbridge.R
@@ -15,8 +15,7 @@
   env[[".setColumnDataAsNominalText"]] <- function(...) return(TRUE)
 
   env[[".allColumnNamesDataset"]]      <- function(...) {
-    dataset <- .getInternal("dataset")
-    dataset <- loadCorrectDataset(dataset)
+    dataset <- jaspBase::getDataSet(dataset)
     return(colnames(dataset))
   }
 }
@@ -25,32 +24,6 @@
 .ppi <- 192
 
 .baseCitation <- "x"
-
-.readDatasetToEndNative <- function(columns = c(), columns.as.numeric = c(), columns.as.ordinal = c(),
-                                    columns.as.factor = c(), all.columns = FALSE) {
-
-  dataset <- .getInternal("dataset")
-  dataset <- loadCorrectDataset(dataset)
-
-  if (all.columns) {
-    columns <- colnames(dataset)
-    columns <- columns[columns != ""]
-  }
-  dataset <- jaspBase:::.vdf(dataset, columns, columns.as.numeric, columns.as.ordinal,
-                        columns.as.factor, all.columns, exclude.na.listwise = c())
-
-  return(dataset)
-}
-
-.readDataSetHeaderNative <- function(columns = c(), columns.as.numeric = c(), columns.as.ordinal = c(),
-                                     columns.as.factor = c(), all.columns = FALSE) {
-
-  dataset <- .readDatasetToEndNative(columns, columns.as.numeric, columns.as.ordinal,
-                                     columns.as.factor, all.columns)
-  dataset <- dataset[0, , drop = FALSE]
-
-  return(dataset)
-}
 
 .requestTempFileNameNative <- function(...) {
   root <- getTempOutputLocation("html")

--- a/R/run.R
+++ b/R/run.R
@@ -139,7 +139,8 @@ initAnalysisRuntime <- function(dataset, makeTests, ...) {
   reinstallChangedModules()
 
   # dataset to be found in the analysis when it needs to be read
-  .setInternal("dataset", dataset)
+  dataset <- loadCorrectDataset(dataset)
+  jaspBase::setDataSet(dataset)
 
   # prevent the results from being translated (unless the user explicitly wants to)
   Sys.setenv(LANG = getPkgOption("language"))


### PR DESCRIPTION
Goes in tandem with: https://github.com/jasp-stats/jaspBase/pull/136

Instead of relying on rbridge finding the `readDatasetToEndNative` in jaspTools, we just rely on the new data set functionality in `jaspBase`. I added jaspBase as a dependency explicitly now (even though we used to call it from jaspTools before as well) - or is there a reason for not doing it? 