### PR TITLE
fix reading in jasp files that are now gzipped

### DIFF
--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -33,38 +33,38 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - uses: r-lib/actions/setup-r-dependencies@v2
-        with:
-          extra-packages: any::rcmdcheck
-          needs: check
+# no longer needed if https://github.com/rstudio/r-system-requirements/issues/81 is resolved
+      - name: Install libarchive on macOS
+        if: runner.os == 'macOS'
+        run: brew install libarchive
 
 #      Ideally we use this, but jaspTools does a lot of things that anger the R CMD Check at the moment...
 #      - uses: r-lib/actions/check-r-package@v2
-      
+
       - name: Check
         run: |
           # ideally we use the one below (the default of r-lib/actions), but jaspTools has some warnings so we use something custom
           #rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran"), error_on = "warning", check_dir = "check")
 
           result <- rcmdcheck::rcmdcheck(
-            args = c("--no-manual", "--as-cran", "--no-examples"), 
-            error_on = "never", 
+            args = c("--no-manual", "--as-cran", "--no-examples"),
+            error_on = "never",
             check_dir = "check"
           )
-          
+
           invalidWarnings <- function(warnings) {
-          
+
             if (length(warnings) == 0L)
               return(FALSE)
-          
+
             # there was one warning when this was created and it's not easy to fix
             if (length(warnings) == 1L && grepl(pattern = "imports not declared", warnings))
               return(FALSE)
-          
+
             # otherwise, new warnings got introduced
             return(TRUE)
           }
-          
+
           if (length(result[["errors"]]) > 0L || invalidWarnings(result[["warnings"]]))
             quit(save = "no", status = 1)
         shell: Rscript {0}

--- a/.github/workflows/rcmdcheck.yml
+++ b/.github/workflows/rcmdcheck.yml
@@ -38,6 +38,11 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install libarchive
 
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck
+          needs: check
+
 #      Ideally we use this, but jaspTools does a lot of things that anger the R CMD Check at the moment...
 #      - uses: r-lib/actions/check-r-package@v2
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,6 +22,6 @@ Imports:
   stringi,
   stringr,
   testthat (>= 3.0.3),
-  vdiffr (>= 1.0.2)
+  vdiffr (>= 1.0.7)
 RoxygenNote: 7.2.3
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,13 +2,16 @@ Package: jaspTools
 Type: Package
 Title: Helps preview and debug JASP analyses
 Version: 0.18.1
-Author: Tim de Jong
-Maintainer: Tim de Jong <tim_jong@hotmail.com>
+Author: Authors@R: c(
+    person("Tim", "de Jong", role = "aut"),
+    person("Don", "van den Bergh", role = c("ctb", "cre"), email = "d.vandenbergh@uva.nl"))
+Maintainer: Don van den Bergh <d.vandenbergh@uva.nl>
 Description: This package assists JASP developers when writing R code. It removes the necessity of building JASP every time a change is made. Rather, analyses can be called directly in R and be debugged interactively.
 License: GNU General Public License
 Encoding: UTF-8
 LazyData: true
 Imports:
+  archive (>= 1.1.6),
   data.table,
   httr,
   jsonlite,

--- a/R/options.R
+++ b/R/options.R
@@ -151,7 +151,7 @@ analysisOptionsFromJASPfile <- function(file) {
   fileIndex <- which(contents[["path"]] == "analyses.json")
 
   if (length(fileIndex) != 1L)
-    stop("Could not determine a file \"analyses.json\" inside the jasp file.")
+    stop("Could not find a file \"analyses.json\" inside the jasp file.")
 
   fileCon <- archive::archive_read(file, file = fileIndex, mode = "r")
   on.exit(close(fileCon))

--- a/R/options.R
+++ b/R/options.R
@@ -146,7 +146,14 @@ analysisOptionsFromJSONString <- function(x) {
 }
 
 analysisOptionsFromJASPfile <- function(file) {
-  fileCon <- unz(file, "analyses.json")
+
+  contents <- archive::archive(file)
+  fileIndex <- which(contents[["path"]] == "analyses.json")
+
+  if (length(fileIndex) != 1L)
+    stop("Could not determine a file \"analyses.json\" inside the jasp file.")
+
+  fileCon <- archive::archive_read(file, file = fileIndex, mode = "r")
   on.exit(close(fileCon))
   contents <- rjson::fromJSON(file = fileCon)
   analyses <- contents[["analyses"]]


### PR DESCRIPTION
Should fix the issue reported by @juliuspfadt on Mattermost.

@Kucharssim I changed myself to the maintainer and removed Tim's email address. I can also add you to the list of authors if you want that. Per CRAN policy there can only be one maintainer listed in the DESCRIPTION file (and doing something else would fail the R CMD check).

I couldn't figure out how to do this without the dependency [`archive`](https://archive.r-lib.org/index.html), but since that uses the same libarchive under the hood that we use in jasp, maybe it's not so bad.