### PR TITLE
increase timeout when downloading jasp-desktop zip

### DIFF
--- a/R/pkg-setup.R
+++ b/R/pkg-setup.R
@@ -162,6 +162,10 @@ fetchJaspDesktopDependencies <- function(jaspdesktopLoc = NULL, branch = "develo
       zipFile <- file.path(baseLoc, "jasp-desktop.zip")
       url <- sprintf("https://github.com/jasp-stats/jasp-desktop/archive/%s.zip", branch)
 
+      # increase the timeout because this sometimes fails on GitHub actions
+      oldTimeout <- getOption("timeout") # defaults to 60 seconds
+      on.exit({options(timeout = oldTimeout)})
+      options(timeout = 300) # 5 minutes
       res <- try(download.file(url = url, destfile = zipFile, quiet = quiet), silent = quiet)
       if (inherits(res, "try-error") || res != 0)
         return(invisible(FALSE))


### PR DESCRIPTION
I got bitten by this again in https://github.com/jasp-stats/jaspJags/actions/runs/8232636788/job/22510499389#step:12:27

There should really be no need to download the jasp-desktop in its entirety, but this at least solves the problem for now.