### PR TITLE
Fix for empty column names

### DIFF
--- a/R/dataset.R
+++ b/R/dataset.R
@@ -51,6 +51,18 @@ findAllColumnNamesInOptions <- function(options, allColumnNames) {
 preloadDataset <- function(datasetPathOrObject, options) {
 
   dataset <- loadCorrectDataset(datasetPathOrObject)
+
+  # repair any names like "", which cause false positives in findAllColumnNamesAndTypes
+  # because empty options are often ""
+  cnms <- colnames(dataset)
+  if (any(cnms == "")) {
+
+    bad <- which(cnms == "")
+    newCnms <- make.names(cnms)
+    cnms[bad] <- newCnms[bad]
+    colnames(dataset) <- cnms
+
+  }
   # columns <- findAllColumnNamesInOptions(options, colnames(dataset))
   temp    <- findAllColumnNamesAndTypes(options, colnames(dataset))
 


### PR DESCRIPTION
[This test file](https://github.com/jasp-stats/jaspDescriptives/blob/master/tests/testthat/irisFertilizer.csv) in jaspDescriptives has an empty column name. I'm not sure what's supposed to happen then in jaspTools, but now we just add a dummy name. Note that indexing with `""` in R causes an error even when the column name equals `""`. And that's exactly what  `findAllColumnNamesAndTypes` tried to do.