### PR TITLE
Do not install jaspBase and jaspGraphs on ci

### DIFF
--- a/R/pkg-setup.R
+++ b/R/pkg-setup.R
@@ -74,18 +74,24 @@ setupJaspTools <- function(pathJaspDesktop = NULL, installJaspModules = FALSE, i
     stop("jaspTools setup could not be completed. Reason: could not fetch the jasp-stats/jasp-desktop repo and as a result the required dependencies are not installed.\n
             If this problem persists clone jasp-stats/jasp-desktop manually.")
 
-  if (isTRUE(installJaspCorePkgs)) {
-    jaspCorePkgs <- if (jaspBaseIsLegacyVersion())
-      c("jaspBase", "jaspGraphs", "jaspResults")
-    else
-      c("jaspBase", "jaspGraphs")
-    installJaspPkg(jaspCorePkgs, quiet = quiet, force = force)
+  if (on_ci) {
+    message("Skipping installation of jaspBase and jaspGraphs on CI.\n")
+  } else {
+  
+    if (isTRUE(installJaspCorePkgs)) {
+      jaspCorePkgs <- if (jaspBaseIsLegacyVersion())
+        c("jaspBase", "jaspGraphs", "jaspResults")
+      else
+        c("jaspBase", "jaspGraphs")
+      installJaspPkg(jaspCorePkgs, quiet = quiet, force = force)
+  
+    }
+  
+    if (isTRUE(installJaspModules))
+      installJaspModules(force = force, quiet = quiet)
 
   }
-
-  if (isTRUE(installJaspModules))
-    installJaspModules(force = force, quiet = quiet)
-
+    
   .finalizeSetup()
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -293,3 +293,12 @@ getGithubHeader <- function() {
   httr::add_headers(Authorization = sprintf("token %s", pat),
                     Accept = "application/vnd.github.golden-comet-preview+json")
 }
+
+# same as the internals in testthat
+env_var_is_true <- function(x) {
+  as.logical(Sys.getenv(x, "false"))
+}
+
+on_ci <- function() {
+  env_var_is_true("CI")
+}


### PR DESCRIPTION
Prerequisite for https://github.com/jasp-stats/jasp-actions/pull/55

otherwise this installs the latest versions of jaspBase & jaspGraphs anyway